### PR TITLE
Downgrading Autofac from v4.8.1 to v4.2.1

### DIFF
--- a/AzureFunctions.Autofac/AzureFunctions.Autofac.csproj
+++ b/AzureFunctions.Autofac/AzureFunctions.Autofac.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.8.1" />
+    <PackageReference Include="Autofac" Version="4.2.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net46'">


### PR DESCRIPTION
The following two issues indicated a problem using the latest version of Autofac (v4.8+) when attempting to run the functions via the Azure Function Host:

- https://github.com/introtocomputerscience/azure-function-autofac-dependency-injection/issues/3
- https://github.com/introtocomputerscience/azure-function-autofac-dependency-injection/issues/7

The following issues of the Azure Function Hosts project indicate a potential problem with the Azure Function Host being dependent upon Autofac v4.2.1.

- https://github.com/Azure/azure-functions-host/issues/2979
- https://github.com/Azure/azure-functions-host/issues/1665

Downgrading Autofac resolves the reported runtime error of the aforementioned issues.