### PR TITLE
Remove specific version dependency for Autofac

### DIFF
--- a/AzureFunctions.Autofac.nuspec
+++ b/AzureFunctions.Autofac.nuspec
@@ -14,11 +14,11 @@
     <repository type="GitHub" url="https://github.com/introtocomputerscience/azure-function-autofac-dependency-injection" />
     <dependencies>
       <group targetFramework=".NETFramework4.6">
-        <dependency id="Autofac" version="[4.2.1]" exclude="Build,Analyzers" />
+        <dependency id="Autofac" version="4.2.1" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Azure.WebJobs" version="2.2.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.0">
-        <dependency id="Autofac" version="[4.2.1]" exclude="Build,Analyzers" />
+        <dependency id="Autofac" version="4.2.1" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Azure.WebJobs" version="3.0.0-rc1" exclude="Build,Analyzers" />
       </group>
     </dependencies>


### PR DESCRIPTION
# Description

This change removes the specific version requirement of Autofac 4.2.1 and instead makes that a minimum version. Using this in a .Net framework function application with newer versions of Autofac was causing the dependency injection methods to not be found and loaded correctly.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I have verified this change works with existing projects and the new project I experienced the issue with. All unit tests are passing.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
