### PR TITLE
README.md got wrong information for Named instances registering in Co…

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Create a class and add a constructor that takes 1 string argument. The string ar
                 //Registration by autofac module
                 builder.RegisterModule(new TestModule());
                 //Named Instances are supported
-                builder.RegisterType<Thing1>().Named<IThing>("OptionA");
-                builder.RegisterType<Thing2>().Named<IThing>("OptionB");
+                builder.RegisterType<Thing1>().As<IThing>().Named<IThing>("OptionA");
+                builder.RegisterType<Thing2>().As<IThing>().Named<IThing>("OptionB");
             }, functionName);
         }
     }


### PR DESCRIPTION
README.md got wrong information for Named instances registering in ContainerBuilder. Corect to include As<>() before the Named<>() mehtod30 

# Description

I was unable to resolve through named dependency injection. I found that I had to put .As<Interface> before the Named<Interface>() method when registering object to the DI container.

Fixes #30 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test Debug the function app and code break inside the methods that contains Named DI inject parameters
- [x] Test Use DependencyInjection.VerifyConfiguration on types that inject named object registration

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
