### PR TITLE
Added capability to register ILoggerFactory into Autofac container

### DIFF
--- a/AzureFunctions.Autofac.NetFramework.Tests/AzureFunctions.Autofac.NetFramework.Tests.csproj
+++ b/AzureFunctions.Autofac.NetFramework.Tests/AzureFunctions.Autofac.NetFramework.Tests.csproj
@@ -43,24 +43,93 @@
     <Reference Include="Autofac, Version=4.6.2.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <HintPath>..\packages\Autofac.4.6.2\lib\net45\Autofac.dll</HintPath>
     </Reference>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Win32.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="Moq, Version=4.9.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.9.0\lib\net45\Moq.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Console, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.3.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Globalization.Calendars, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Globalization.Calendars.4.3.0\lib\net46\System.Globalization.Calendars.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
+    </Reference>
     <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.IO.Compression.ZipFile, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Compression.ZipFile.4.3.0\lib\net46\System.IO.Compression.ZipFile.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.FileSystem, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.4.3.0\lib\net46\System.IO.FileSystem.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Http.4.3.0\lib\net46\System.Net.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Sockets, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Sockets.4.3.0\lib\net46\System.Net.Sockets.dll</HintPath>
+    </Reference>
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Xml.ReaderWriter, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.ReaderWriter.4.3.0\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ContainerBuilderExtensionsTests.cs" />
     <Compile Include="DependencyInjectionVerificationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/AzureFunctions.Autofac.NetFramework.Tests/ContainerBuilderExtensionsTests.cs
+++ b/AzureFunctions.Autofac.NetFramework.Tests/ContainerBuilderExtensionsTests.cs
@@ -1,0 +1,65 @@
+﻿using Autofac;
+using Autofac.Core;
+using AzureFunctions.Autofac.Shared.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace AzureFunctions.Autofac.NetFramework.Tests
+{
+    [TestClass]
+    public class ContainerBuilderExtensionsTests
+    {
+        [TestMethod]
+        public void ContainerBuilderExtension_Should_AllowToProvideILogger_When_LoggerFactoryIsGivenToTheContainer()
+        {
+            var loggerFactory = new Mock<ILoggerFactory>();
+            var logger = new Mock<ILogger>();
+            loggerFactory
+                .Setup(lf => lf.CreateLogger("AzureFunctions.Autofac.NetFramework.Tests.ContainerBuilderExtensionsTests.TestService"))
+                .Returns(logger.Object);
+
+            var builder = new ContainerBuilder();
+            builder.RegisterLoggerFactory(loggerFactory.Object);
+            builder.RegisterType<TestService>();
+            var container = builder.Build();
+
+            // In order to provide an instance of TestService, the container has to build a Logger<>,
+            // which requires a properly configured ILoggerFactory instance
+            var service = container.Resolve<TestService>();
+
+            Assert.IsNotNull(service.Logger);
+            Assert.IsInstanceOfType(service.Logger, typeof(Logger<TestService>));
+
+            // The factory should have been requested to populate the inner logger of the Logger<> wrapper,
+            // to ensure it uses the config & providers setup for the app
+            loggerFactory
+                .Verify(
+                    lf => lf.CreateLogger(
+                        "AzureFunctions.Autofac.NetFramework.Tests.ContainerBuilderExtensionsTests.TestService"),
+                    Times.Once);
+        }
+
+        [TestMethod]
+        public void ContainerBuilderExtension_Should_FailToProvideILogger_When_NoLoggerFactoryIsGivenToTheContainer()
+        {
+            var builder = new ContainerBuilder();
+            // Register only TestService, but do not give any ILoggerFactory to the container
+            builder.RegisterType<TestService>();
+            var container = builder.Build();
+
+            var ex = Assert.ThrowsException<DependencyResolutionException>(() => container.Resolve<TestService>());
+            Assert.IsTrue(ex.Message.Contains("TestService"));
+        }
+
+        private class TestService
+        {
+            public ILogger<TestService> Logger { get; }
+
+            public TestService(ILogger<TestService> logger)
+            {
+                Logger = logger;
+            }
+        }
+    }
+}

--- a/AzureFunctions.Autofac.NetFramework.Tests/packages.config
+++ b/AzureFunctions.Autofac.NetFramework.Tests/packages.config
@@ -1,6 +1,57 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="4.6.2" targetFramework="net46" />
+  <package id="Castle.Core" version="4.3.1" targetFramework="net46" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="1.1.1" targetFramework="net46" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net46" />
+  <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net46" />
+  <package id="Moq" version="4.9.0" targetFramework="net46" />
   <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net46" />
   <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net46" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net46" />
+  <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net46" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net46" />
+  <package id="System.Console" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net46" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net46" />
+  <package id="System.Globalization.Calendars" version="4.3.0" targetFramework="net46" />
+  <package id="System.IO" version="4.3.0" targetFramework="net46" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net46" />
+  <package id="System.IO.Compression.ZipFile" version="4.3.0" targetFramework="net46" />
+  <package id="System.IO.FileSystem" version="4.3.0" targetFramework="net46" />
+  <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net46" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net46" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net46" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net46" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net46" />
+  <package id="System.Net.Sockets" version="4.3.0" targetFramework="net46" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net46" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net46" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net46" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net46" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net46" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net46" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net46" />
+  <package id="System.Runtime.Handles" version="4.3.0" targetFramework="net46" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net46" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net46" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net46" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net46" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net46" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading.Timer" version="4.3.0" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net46" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net46" />
 </packages>

--- a/AzureFunctions.Autofac.NetStandard.Tests/AzureFunctions.Autofac.NetStandard.Tests.csproj
+++ b/AzureFunctions.Autofac.NetStandard.Tests/AzureFunctions.Autofac.NetStandard.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Moq" Version="4.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
   </ItemGroup>

--- a/AzureFunctions.Autofac.NetStandard.Tests/ContainerBuilderExtensionsTests.cs
+++ b/AzureFunctions.Autofac.NetStandard.Tests/ContainerBuilderExtensionsTests.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Autofac;
+using Autofac.Core;
+using AzureFunctions.Autofac.Shared.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace AzureFunctions.Autofac.NetStandard.Tests
+{
+    [TestClass]
+    public class ContainerBuilderExtensionsTests
+    {
+        [TestMethod]
+        public void ContainerBuilderExtension_Should_AllowToProvideILogger_When_LoggerFactoryIsGivenToTheContainer()
+        {
+            var loggerFactory = new Mock<ILoggerFactory>();
+            var logger = new Mock<ILogger>();
+            loggerFactory
+                .Setup(lf => lf.CreateLogger("AzureFunctions.Autofac.NetStandard.Tests.ContainerBuilderExtensionsTests.TestService"))
+                .Returns(logger.Object);
+
+            var builder = new ContainerBuilder();
+            builder.RegisterLoggerFactory(loggerFactory.Object);
+            builder.RegisterType<TestService>();
+            var container = builder.Build();
+
+            // In order to provide an instance of TestService, the container has to build a Logger<>,
+            // which requires a properly configured ILoggerFactory instance
+            var service = container.Resolve<TestService>();
+
+            Assert.IsNotNull(service.Logger);
+            Assert.IsInstanceOfType(service.Logger, typeof(Logger<TestService>));
+
+            // The factory should have been requested to populate the inner logger of the Logger<> wrapper,
+            // to ensure it uses the config & providers setup for the app
+            loggerFactory
+                .Verify(
+                    lf => lf.CreateLogger(
+                        "AzureFunctions.Autofac.NetStandard.Tests.ContainerBuilderExtensionsTests.TestService"),
+                    Times.Once);
+        }
+
+        [TestMethod]
+        public void ContainerBuilderExtension_Should_FailToProvideILogger_When_NoLoggerFactoryIsGivenToTheContainer()
+        {
+            var builder = new ContainerBuilder();
+            // Register only TestService, but do not give any ILoggerFactory to the container
+            builder.RegisterType<TestService>();
+            var container = builder.Build();
+
+            var ex = Assert.ThrowsException<DependencyResolutionException>(() => container.Resolve<TestService>());
+            Assert.IsTrue(ex.Message.Contains("TestService"));
+        }
+
+        private class TestService
+        {
+            public ILogger<TestService> Logger { get; }
+
+            public TestService(ILogger<TestService> logger)
+            {
+                Logger = logger;
+            }
+        }
+    }
+}

--- a/AzureFunctions.Autofac.Shared/Extensions/ContainerBuilderExtensions.cs
+++ b/AzureFunctions.Autofac.Shared/Extensions/ContainerBuilderExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Autofac;
+using Microsoft.Extensions.Logging;
+
+namespace AzureFunctions.Autofac.Shared.Extensions
+{
+    public static class ContainerBuilderExtensions
+    {
+        public static void RegisterLoggerFactory(this ContainerBuilder builder, ILoggerFactory factory)
+        {
+            builder.RegisterInstance(factory).As<ILoggerFactory>().SingleInstance();
+            builder.RegisterGeneric(typeof(Logger<>)).As(typeof(ILogger<>)).SingleInstance();
+        }
+    }
+}

--- a/AzureFunctions.Autofac.Shared/Provider/Binding/InjectBindingProvider.cs
+++ b/AzureFunctions.Autofac.Shared/Provider/Binding/InjectBindingProvider.cs
@@ -38,6 +38,7 @@ namespace AzureFunctions.Autofac
 
             //Initialize DependencyInjection
             var functionAndAppDirectoryAndLoggerFactoryConstructor = attribute.Config.GetConstructor(new[] { typeof(string), typeof(string), typeof(ILoggerFactory) });
+            var functionAndAppLoggerFactoryConstructor = attribute.Config.GetConstructor(new[] { typeof(string), typeof(ILoggerFactory) });
             var functionAndAppDirectoryConstructor = attribute.Config.GetConstructor(new[] { typeof(string), typeof(string) });
 
             if (functionAndAppDirectoryAndLoggerFactoryConstructor != null)
@@ -47,6 +48,10 @@ namespace AzureFunctions.Autofac
             else if (functionAndAppDirectoryConstructor != null)
             {
                 Activator.CreateInstance(attribute.Config, functionName, _appDirectory);
+            }
+            else if (functionAndAppLoggerFactoryConstructor != null)
+            {
+                Activator.CreateInstance(attribute.Config, functionName, _loggerFactory);
             }
             else
             {

--- a/AzureFunctions.Autofac.Shared/Provider/Config/InjectExtensionConfigProvider.cs
+++ b/AzureFunctions.Autofac.Shared/Provider/Config/InjectExtensionConfigProvider.cs
@@ -16,26 +16,26 @@ namespace AzureFunctions.Autofac.Provider.Config
 {
     public class InjectExtensionConfigProvider : IExtensionConfigProvider
     {
-        private readonly InjectBindingProvider bindingProvider;
+        private InjectBindingProvider _bindingProvider;
 
 #if NET46
-        public InjectExtensionConfigProvider()
-        {
-            this.bindingProvider = new InjectBindingProvider();
-        }
+        public InjectExtensionConfigProvider() { }
 #endif
 
 #if NETSTANDARD2_0
         public InjectExtensionConfigProvider(IOptions<ExecutionContextOptions> options, ILoggerFactory loggerFactory)
         {
             var appDirectory = options.Value.AppDirectory;
-            this.bindingProvider = new InjectBindingProvider(appDirectory, loggerFactory);
+            this._bindingProvider = new InjectBindingProvider(appDirectory, loggerFactory);
         }
 #endif
 
         public void Initialize(ExtensionConfigContext context)
         {
-            context.AddBindingRule<InjectAttribute>().Bind(this.bindingProvider);
+#if NET46
+            this._bindingProvider = new InjectBindingProvider(null,context.Config.LoggerFactory);
+#endif
+            context.AddBindingRule<InjectAttribute>().Bind(this._bindingProvider);
         }
     }
 }

--- a/AzureFunctions.Autofac.Shared/Provider/Config/InjectExtensionConfigProvider.cs
+++ b/AzureFunctions.Autofac.Shared/Provider/Config/InjectExtensionConfigProvider.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 
 #if NETSTANDARD2_0
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 #endif
 
@@ -16,22 +17,22 @@ namespace AzureFunctions.Autofac.Provider.Config
     public class InjectExtensionConfigProvider : IExtensionConfigProvider
     {
         private readonly InjectBindingProvider bindingProvider;
-        
-        #if NET46
+
+#if NET46
         public InjectExtensionConfigProvider()
         {
             this.bindingProvider = new InjectBindingProvider();
         }
-        #endif
-        
-        #if NETSTANDARD2_0
-        public InjectExtensionConfigProvider(IOptions<ExecutionContextOptions> options)
+#endif
+
+#if NETSTANDARD2_0
+        public InjectExtensionConfigProvider(IOptions<ExecutionContextOptions> options, ILoggerFactory loggerFactory)
         {
             var appDirectory = options.Value.AppDirectory;
-            this.bindingProvider = new InjectBindingProvider(appDirectory);
+            this.bindingProvider = new InjectBindingProvider(appDirectory, loggerFactory);
         }
-        #endif
-        
+#endif
+
         public void Initialize(ExtensionConfigContext context)
         {
             context.AddBindingRule<InjectAttribute>().Bind(this.bindingProvider);

--- a/NetCoreExample/Functions/LoggerFunction.cs
+++ b/NetCoreExample/Functions/LoggerFunction.cs
@@ -5,7 +5,7 @@ using AutofacDIExample.Resolvers;
 using AzureFunctions.Autofac;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
-using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Extensions.Logging;
 
 namespace NetCoreExample.Functions
 {
@@ -14,10 +14,11 @@ namespace NetCoreExample.Functions
     {
         [FunctionName("LoggerFunction")]
         public static HttpResponseMessage Run([HttpTrigger(AuthorizationLevel.Function, "get", Route = null)]HttpRequestMessage request,
-            TraceWriter log,
+            ILogger log,
             [Inject]ILogWriter writer)
         {
-            log.Info("C# HTTP trigger function processed a request.");
+            log.LogInformation("C# HTTP trigger function processed a request.");
+            writer.Log();
             return request.CreateResponse(HttpStatusCode.OK, "Autofac managed to inject a ILogger<>");
         }
     }

--- a/NetCoreExample/Functions/LoggerFunction.cs
+++ b/NetCoreExample/Functions/LoggerFunction.cs
@@ -1,0 +1,24 @@
+using System.Net;
+using System.Net.Http;
+using AutofacDIExample;
+using AutofacDIExample.Resolvers;
+using AzureFunctions.Autofac;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.WebJobs.Host;
+
+namespace NetCoreExample.Functions
+{
+    [DependencyInjectionConfig(typeof(DIWithLoggerFactoryConfig))]
+    public class LoggerFunction
+    {
+        [FunctionName("LoggerFunction")]
+        public static HttpResponseMessage Run([HttpTrigger(AuthorizationLevel.Function, "get", Route = null)]HttpRequestMessage request,
+            TraceWriter log,
+            [Inject]ILogWriter writer)
+        {
+            log.Info("C# HTTP trigger function processed a request.");
+            return request.CreateResponse(HttpStatusCode.OK, "Autofac managed to inject a ILogger<>");
+        }
+    }
+}

--- a/NetCoreExample/Interfaces/ILogWriter.cs
+++ b/NetCoreExample/Interfaces/ILogWriter.cs
@@ -1,0 +1,7 @@
+﻿namespace AutofacDIExample
+{
+    public interface ILogWriter
+    {
+        void Log();
+    }
+}

--- a/NetCoreExample/Models/LogWriter.cs
+++ b/NetCoreExample/Models/LogWriter.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace AutofacDIExample
+{
+    public class LogWriter : ILogWriter
+    {
+        private readonly ILogger<LogWriter> _logger;
+
+        public LogWriter(ILogger<LogWriter> logger)
+        {
+            _logger = logger;
+        }
+
+        public void Log()
+        {
+            _logger.LogInformation("Hello Developer!");
+        }
+    }
+}

--- a/NetCoreExample/Modules/TestModule.cs
+++ b/NetCoreExample/Modules/TestModule.cs
@@ -10,6 +10,7 @@ namespace AutofacDIExample.Modules
             builder.RegisterType<Greeter>().As<IGreeter>();
             builder.RegisterType<Goodbyer>().Named<IGoodbyer>("Main");
             builder.RegisterType<AlternateGoodbyer>().Named<IGoodbyer>("Secondary");
+            builder.RegisterType<LogWriter>().As<ILogWriter>();
 
         }
     }

--- a/NetCoreExample/Resolvers/DIWithLoggerFactoryConfig.cs
+++ b/NetCoreExample/Resolvers/DIWithLoggerFactoryConfig.cs
@@ -1,0 +1,20 @@
+﻿using Autofac;
+using AutofacDIExample.Modules;
+using AzureFunctions.Autofac.Configuration;
+using AzureFunctions.Autofac.Shared.Extensions;
+using Microsoft.Extensions.Logging;
+
+namespace AutofacDIExample.Resolvers
+{
+    public class DIWithLoggerFactoryConfig
+    {
+        public DIWithLoggerFactoryConfig(string functionName, ILoggerFactory factory)
+        {
+            DependencyInjection.Initialize(builder =>
+            {
+                builder.RegisterModule(new TestModule());
+                builder.RegisterLoggerFactory(factory);
+            }, functionName);
+        }
+    }
+}

--- a/NetFrameworkExample/Functions/GreeterFunction.cs
+++ b/NetFrameworkExample/Functions/GreeterFunction.cs
@@ -6,7 +6,7 @@ using Microsoft.Azure.WebJobs.Host;
 using System.Net;
 using System.Net.Http;
 
-namespace AutofacDIExample.GreeterFunction
+namespace AutofacDIExample.Functions
 {
     [DependencyInjectionConfig(typeof(DIConfig))]
     public class GreeterFunction

--- a/NetFrameworkExample/Functions/LoggerFunction.cs
+++ b/NetFrameworkExample/Functions/LoggerFunction.cs
@@ -1,0 +1,24 @@
+using System.Net;
+using System.Net.Http;
+using AutofacDIExample;
+using AutofacDIExample.Resolvers;
+using AzureFunctions.Autofac;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.WebJobs.Host;
+
+namespace AutofacDIExample.Functions
+{
+    [DependencyInjectionConfig(typeof(DIWithLoggerFactoryConfig))]
+    public class LoggerFunction
+    {
+        [FunctionName("LoggerFunction")]
+        public static HttpResponseMessage Run([HttpTrigger(AuthorizationLevel.Function, "get", Route = null)]HttpRequestMessage request,
+            TraceWriter log,
+            [Inject]ILogWriter writer)
+        {
+            log.Info("C# HTTP trigger function processed a request.");
+            return request.CreateResponse(HttpStatusCode.OK, "Autofac managed to inject a ILogger<>");
+        }
+    }
+}

--- a/NetFrameworkExample/Interfaces/ILogWriter.cs
+++ b/NetFrameworkExample/Interfaces/ILogWriter.cs
@@ -1,0 +1,7 @@
+﻿namespace AutofacDIExample
+{
+    public interface ILogWriter
+    {
+        void Log();
+    }
+}

--- a/NetFrameworkExample/Models/LogWriter.cs
+++ b/NetFrameworkExample/Models/LogWriter.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace AutofacDIExample
+{
+    public class LogWriter : ILogWriter
+    {
+        private readonly ILogger<LogWriter> _logger;
+
+        public LogWriter(ILogger<LogWriter> logger)
+        {
+            _logger = logger;
+        }
+
+        public void Log()
+        {
+            _logger.LogInformation("Hello Developer!");
+        }
+    }
+}

--- a/NetFrameworkExample/Modules/TestModule.cs
+++ b/NetFrameworkExample/Modules/TestModule.cs
@@ -10,6 +10,7 @@ namespace AutofacDIExample.Modules
             builder.RegisterType<Greeter>().As<IGreeter>();
             builder.RegisterType<Goodbyer>().Named<IGoodbyer>("Main");
             builder.RegisterType<AlternateGoodbyer>().Named<IGoodbyer>("Secondary");
+            builder.RegisterType<LogWriter>().As<ILogWriter>();
 
         }
     }

--- a/NetFrameworkExample/Resolvers/DIWithLoggerFactoryConfig.cs
+++ b/NetFrameworkExample/Resolvers/DIWithLoggerFactoryConfig.cs
@@ -1,0 +1,20 @@
+﻿using Autofac;
+using AutofacDIExample.Modules;
+using AzureFunctions.Autofac.Configuration;
+using AzureFunctions.Autofac.Shared.Extensions;
+using Microsoft.Extensions.Logging;
+
+namespace AutofacDIExample.Resolvers
+{
+    public class DIWithLoggerFactoryConfig
+    {
+        public DIWithLoggerFactoryConfig(string functionName, ILoggerFactory factory)
+        {
+            DependencyInjection.Initialize(builder =>
+            {
+                builder.RegisterModule(new TestModule());
+                builder.RegisterLoggerFactory(factory);
+            }, functionName);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ In order to implement the dependency injection you have to create a class to con
 
 The configuration class is used to setup dependency injestion. Within the constructor of the class DependencyInjection.Initialize must be invoked. Registrations are then according to standard Autofac procedures.  
 
-In both .NET Framework and .NET Core a required functionName parameter is automatically injected for you but you must specify it as a constructor parameter.  
+In both .NET Framework and .NET Core a required functionName parameter is automatically injected for you but you must specify it as a constructor parameter. You can also use the optional ILoggerFactory parameter, to register it into the container, and therefore allow Autofac to inject ILogger<> into your services.
 
-In .NET Core you have an optional baseDirectory parameter that can be used for loading external app configs. If you wish to use this functionality then you must specify this as a constructor parameter and it will be injected for you.
+In .NET Core you have another optional baseDirectory parameter that can be used for loading external app configs. If you wish to use this functionality then you must specify this as a constructor parameter and it will be injected for you.
 
 #### Functions V1 Example (.NET Framework)
 
@@ -43,7 +43,7 @@ In .NET Core you have an optional baseDirectory parameter that can be used for l
 ```c#
     public class DIConfig
     {
-        public DIConfig(string functionName, string baseDirectory)
+        public DIConfig(string functionName, string baseDirectory, ILoggerFactory factory)
         {
             DependencyInjection.Initialize(builder =>
             {
@@ -56,6 +56,8 @@ In .NET Core you have an optional baseDirectory parameter that can be used for l
                 //Named Instances are supported
                 builder.RegisterType<Thing1>().Named<IThing>("OptionA");
                 builder.RegisterType<Thing2>().Named<IThing>("OptionB");
+                // Configure Autofac to provide ILogger<> into constructors
+                builder.RegisterLoggerFactory(factory);
             }, functionName);
         }
     }


### PR DESCRIPTION
# Description

Registering the app ILoggerFactory into the container enables to inject ILogger<> into resolved services.
It's optional, so it won't change the existing usages, but it's a needed addition for our case, where the services we inject require dedicated loggers behind the scenes.
This change contains an extension method to assist developers in the registration of the ILoggerFactory

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

I updated the Azure function projects (both NetCore and NetFramework), and ensured that services with ILogger<> in constructors can be provided by Autofac ;

- [x] LoggerFunction in NetFramework, which builds a ILogWriter
- [x] Exact same test in NetCore

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
