### PR TITLE
Include an example of ILogger<> injection in the .NET Core example

### DIFF
--- a/NetCoreExample/Models/Goodbyer.cs
+++ b/NetCoreExample/Models/Goodbyer.cs
@@ -1,9 +1,24 @@
-﻿namespace AutofacDIExample
+﻿using Microsoft.Extensions.Logging;
+
+namespace AutofacDIExample
 {
     public class Goodbyer : IGoodbyer
     {
+        private readonly ILogger<Goodbyer> logger;
+
+        public Goodbyer(ILogger<Goodbyer> logger)
+        {
+            this.logger = logger;
+        }
+
         public string Goodbye()
         {
+            // To see this in the Azure Function CLI window you need to provide a logging configuration in host.json 
+            //    that enables the warning level either for everything or for this class
+            //     For more information see 
+            //     https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/?view=aspnetcore-3.1#configuration
+            logger.LogWarning("Saying goodbye");
+
             return "So long...";
         }
     }

--- a/NetCoreExample/Resolvers/DIConfig.cs
+++ b/NetCoreExample/Resolvers/DIConfig.cs
@@ -2,7 +2,9 @@
 using AutofacDIExample.Modules;
 using AzureFunctions.Autofac;
 using AzureFunctions.Autofac.Configuration;
+using AzureFunctions.Autofac.Shared.Extensions;
 using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Extensions.Logging;
 using NetCoreExample.Interfaces;
 using NetCoreExample.Models;
 using System;
@@ -11,12 +13,13 @@ namespace AutofacDIExample.Resolvers
 {
     public class DIConfig
     {
-        public DIConfig(string functionName, string baseDirectory)
+        public DIConfig(string functionName, string baseDirectory, ILoggerFactory factory)
         {
             DependencyInjection.Initialize(builder =>
             {
                 builder.RegisterModule(new TestModule());
                 builder.Register<DirectoryAnnouncer>(c => new DirectoryAnnouncer(baseDirectory)).As<IAnnouncer>();
+                builder.RegisterLoggerFactory(factory);
             }, functionName);
         }
     }

--- a/NetCoreExample/host.json
+++ b/NetCoreExample/host.json
@@ -1,3 +1,10 @@
 {
-  "version": "2.0"
+  "version": "2.0",
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "System": "Warning",
+      "Microsoft": "Warning"
+    }
+  }
 }


### PR DESCRIPTION
# Description

This change only affects the example and shows how to enable logging for injected loggers, it does not change any functionality in the packaged version.

I've updated the "Goodbyer" component to use an injected ILogger<> as an example of how this works in production. I've also updated the host.json to include information level logging by default as an example of how to do this. This was based on my spending a few hours not being able to work out why my logs weren't being written out while I was doing some troubleshooting and also in response to #52.

Hopefully this addresses issue #52 

## Type of change

Please delete options that are not relevant.

- [ ] Documentation update

# How Has This Been Tested?

Only the NetCoreExample project has been changed and this still runs as normal after the changes. No changes to the package code made and all unit tests still passing.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
