### PR TITLE
Feature/removing autofac version

### DIFF
--- a/AzureFunctions.Autofac.Shared/AzureFunctions.Autofac.Shared.csproj
+++ b/AzureFunctions.Autofac.Shared/AzureFunctions.Autofac.Shared.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>3.0.6</Version>
+    <Version>4.0.0-alpha</Version>
     <Authors>CJ van der Smissen</Authors>
     <Company />
     <Product />
@@ -12,9 +12,10 @@
     <PackageProjectUrl>https://github.com/introtocomputerscience/azure-function-autofac-dependency-injection</PackageProjectUrl>
     <RepositoryUrl>https://github.com/introtocomputerscience/azure-function-autofac-dependency-injection</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
-    <PackageReleaseNotes>Added feature to verify the dependency injection configuration for a given type.</PackageReleaseNotes>
+    <PackageReleaseNotes>Removing restriction of autofac as Azure Functions is no longer limiting this.</PackageReleaseNotes>
     <PackageLicenseUrl>https://github.com/introtocomputerscience/azure-function-autofac-dependency-injection/blob/master/LICENSE</PackageLicenseUrl>
-    <AssemblyVersion>3.0.6.0</AssemblyVersion>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <FileVersion>4.0.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="[4.6.2]" />
+    <PackageReference Include="Autofac" Version="4.6.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>
 

--- a/AzureFunctions.Autofac.Shared/AzureFunctions.Autofac.Shared.csproj
+++ b/AzureFunctions.Autofac.Shared/AzureFunctions.Autofac.Shared.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>4.0.0-alpha</Version>
+    <Version>4.0.0</Version>
     <Authors>CJ van der Smissen</Authors>
     <Company />
     <Product />

--- a/AzureFunctions.Autofac.nuspec
+++ b/AzureFunctions.Autofac.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>AzureFunctions.Autofac</id>
-    <version>4.0.0-alpha</version>
+    <version>4.0.0</version>
     <authors>CJ van der Smissen</authors>
     <owners>CJ van der Smissen</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/AzureFunctions.Autofac.nuspec
+++ b/AzureFunctions.Autofac.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>AzureFunctions.Autofac</id>
-    <version>3.1.0</version>
+    <version>4.0.0-alpha</version>
     <authors>CJ van der Smissen</authors>
     <owners>CJ van der Smissen</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/introtocomputerscience/azure-function-autofac-dependency-injection</projectUrl>
     <description>Autofac Implementation of DI for Azure Functions</description>
     <releaseNotes>
-      Updated Autofac to 4.6.2 to match the change that azure functions core tools made in 2.0.12961
+      Removing restriction of autofac as Azure Functions is no longer limiting this.
     </releaseNotes>
     <copyright>2017</copyright>
     <repository type="GitHub" url="https://github.com/introtocomputerscience/azure-function-autofac-dependency-injection" />

--- a/AzureFunctions.Autofac.nuspec
+++ b/AzureFunctions.Autofac.nuspec
@@ -16,11 +16,11 @@
     <repository type="GitHub" url="https://github.com/introtocomputerscience/azure-function-autofac-dependency-injection" />
     <dependencies>
       <group targetFramework=".NETFramework4.6">
-        <dependency id="Autofac" version="[4.6.2]" exclude="Build,Analyzers" />
+        <dependency id="Autofac" version="4.6.2" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Azure.WebJobs" version="2.2.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.0">
-        <dependency id="Autofac" version="[4.6.2]" exclude="Build,Analyzers" />
+        <dependency id="Autofac" version="4.6.2" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Azure.WebJobs" version="3.0.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>


### PR DESCRIPTION
Small change but big effect. Removed the restriction on the version of autofac as Azure Functions now appears to allow you to use whichever version you would like. 

This has been tested over the past month and I have not found issues. 